### PR TITLE
Limit analysis

### DIFF
--- a/draft-thomson-ppm-prss.md
+++ b/draft-thomson-ppm-prss.md
@@ -537,7 +537,7 @@ The number of uses (`p`) are only affected by the second component, as the first
 component is unaffected by usage of the permutation.  However, the first
 component guides our assumptions about the number of times the attacker might be
 willing to invoke the permutation (`q`). The result shows that statistical security is
-provided based on the birthday bound. For instance, `q` being 2<sup>-64</sup>
+provided based on the birthday bound. For instance, `q` being 2<sup>64</sup>
 results in a disastrous advantage of 0.5 for the AES-128 key size of 128 bits.
 This first term therefore places an upper bound on the value that `q` can take
 before an attacker can rely solely on this computational limit.

--- a/draft-thomson-ppm-prss.md
+++ b/draft-thomson-ppm-prss.md
@@ -568,13 +568,14 @@ leads to a limit for `p` of `2^(b-(k+a)/2-2)`.  For example, to obtain 40 bits
 of security, the value of `p` for AES-128 is limited to 2<sup>42</sup>, which
 assumes a value of `q` no more than 2<sup>44</sup>.
 
-For AES-256, the first component is negligible with a similar value for the same
-`q`.  However, with the same block size, a larger value of `q` only reduces the
-value of `p` that is permitted.  Using the same assumed value for `q` as in the
-AES-128 analysis allows the limit to be doubled (to 2<sup>43</sup> for 40 bits
-of security), given that the value for the first component is negligible.  That
-is, limiting `q` to 2<sup>44</sup> leads to the first component being at most
-2<sup>-169</sup>.
+For AES-256, the larger key size means that the first component is negligible
+for any value of `q`, unless `p` and `a` are both very small.  This is due to
+AES-256 having the same 128-bit block size as AES-128.  Consequently, increasing
+`q` only reduces the value of `p`.
+
+On this basis, the same `q` value can be used for AES-256 as for AES-128. The
+usage limit for AES-256 can be doubled to `2^(b-(k+a)/2-1)` (2<sup>43</sup> for
+40 bits of security; the first component is the negligible 2<sup>-169</sup>).
 
 This analysis models AES as an ideal pseudorandom permutation.
 

--- a/draft-thomson-ppm-prss.md
+++ b/draft-thomson-ppm-prss.md
@@ -336,7 +336,7 @@ information is summarized in {{table-prf}}.
 | PRF Name | Identifier | Nk | Mi | Mo |
 |:--|--:|--:|--:|--:|--:|
 | PRF_AES_128 | 0x0001 | 16 | 2<sup>42</sup> | 2<sup>128</sup> |
-| PRF_AES_256 | 0x0002 | 32 | 2<sup>42</sup> | 2<sup>128</sup> |
+| PRF_AES_256 | 0x0002 | 32 | 2<sup>43</sup> | 2<sup>128</sup> |
 {: #table-prf title="Pseudorandom Function Summary"}
 
 Both AES PRFs use the same process:

--- a/draft-thomson-ppm-prss.md
+++ b/draft-thomson-ppm-prss.md
@@ -575,7 +575,7 @@ AES-256 having the same 128-bit block size as AES-128.  Consequently, increasing
 
 On this basis, the same `q` value can be used for AES-256 as for AES-128. The
 usage limit for AES-256 can be doubled to `2^(b-(k+a)/2-1)` (2<sup>43</sup> for
-40 bits of security; the first component is the negligible 2<sup>-169</sup>).
+40 bits of security; the first component is a negligible 2<sup>-169</sup>).
 
 This analysis models AES as an ideal pseudorandom permutation.
 

--- a/draft-thomson-ppm-prss.md
+++ b/draft-thomson-ppm-prss.md
@@ -536,7 +536,7 @@ PRP and shows that attacker advantage comprises two components:
 The number of uses (`p`) are only affected by the second component, as the first
 component is unaffected by usage of the permutation.  However, the first
 component guides our assumptions about the number of times the attacker might be
-willing to invoke the permutation. The result shows that statistical security is
+willing to invoke the permutation (`q`). The result shows that statistical security is
 provided based on the birthday bound. For instance, `q` being 2<sup>-64</sup>
 results in a disastrous advantage of 0.5 for the AES-128 key size of 128 bits.
 This first term therefore places an upper bound on the value that `q` can take

--- a/draft-thomson-ppm-prss.md
+++ b/draft-thomson-ppm-prss.md
@@ -162,7 +162,7 @@ in most cases.
 
 This document uses the system of describing, naming, and identifying KEMs
 defined in {{!HPKE=RFC9180}}.  For use in PRSS, a KEM is first chosen for use.
-KEM identifiers from {{Section 7.1 of !HPKE}} MAY be used for identification or
+KEM identifiers from {{Section 7.1 of !HPKE}} could used for identification or
 negotiation.
 
 Once a KEM is chosen, one participant is assigned the "sender" role; the other


### PR DESCRIPTION
I spent some time with this and concluded that our limits were not good in the first time around.  A more careful analysis shows that we are still OK, but the limits are closer than ideal.  We're assuming $2^{44}$ work for the adversary here for 40 bits of security, which is probably fine, though it is much weaker than the same analysis I've seen for cipher usage elsewhere.

Concrete numbers: $2^{64}$ becomes $2^{42}$ for AES-128 (double that for AES-256).