### PR TITLE
remove quotes around semi-honest security

### DIFF
--- a/draft-savage-ppm-3phm-mpc.md
+++ b/draft-savage-ppm-3phm-mpc.md
@@ -377,7 +377,7 @@ replicated secret sharing of the product of `x` and `y`.
 # Validation Protocol {#validation}
 
 The basic multiplication protocol in {{multiplication}} only offers semi-honest
-security. It is "secure up to an additive attack". Validating multiplications
+security. It is secure up to an additive attack; see {{additive-attack}}. Validating multiplications
 allows an additive attack to be detected, ensuring that a protocol is aborted
 before any result is produced that might compromise the confidentiality of
 inputs.

--- a/draft-savage-ppm-3phm-mpc.md
+++ b/draft-savage-ppm-3phm-mpc.md
@@ -376,8 +376,8 @@ replicated secret sharing of the product of `x` and `y`.
 
 # Validation Protocol {#validation}
 
-The basic multiplication protocol in {{multiplication}} only offers "semi-honest
-security". It is "secure up to an additive attack". Validating multiplications
+The basic multiplication protocol in {{multiplication}} only offers semi-honest
+security. It is "secure up to an additive attack". Validating multiplications
 allows an additive attack to be detected, ensuring that a protocol is aborted
 before any result is produced that might compromise the confidentiality of
 inputs.


### PR DESCRIPTION
This is the only place the term "semi-honest security" is used in the document. Quotes aren't necessary unless quoting from elsewhere (in the doc or in another), or defining a term.